### PR TITLE
fix: skip the tx outcome of the gas token transfer transaction

### DIFF
--- a/src/core/setupBTCWallet.ts
+++ b/src/core/setupBTCWallet.ts
@@ -428,7 +428,8 @@ const BTCWallet: WalletBehaviourFactory<InjectedWallet> = async ({
     });
     await checkBtcTransactionStatus(currentConfig.base_url, signature);
 
-    const hash = newTrans.map((t) => t.hash);
+    // Skip the outcome of the first transaction, which is the gas token transfer transaction
+    const hash = newTrans.slice(1).map((t) => t.hash);
     console.log('txHash:', hash);
     const result = await pollTransactionStatuses(options.network.networkId, hash);
     return result;


### PR DESCRIPTION
We met one issue when testing with Satoshi BTC Wallet:

> The transaction result of `signAndSendTransaction()` will be the result of the nBTC gas transfer transaction, rather than the actual transaction executed by user, which brings troubles when caller wants to get the function call result.

To fix this, we should skip the first transaction (gas token transfer transaction) before polling transactions results. 